### PR TITLE
FIX, classic dark name

### DIFF
--- a/themes/Xcode Classic Dark.json
+++ b/themes/Xcode Classic Dark.json
@@ -1,5 +1,5 @@
 {
-  "name": "Xcode 12 Default Dark",
+  "name": "Xcode Classic Dark",
   "type": "dark",
   "colors": {
     "activityBar.background": "#282831",


### PR DESCRIPTION
The name used in `Xcode Classic Dark.json` was "Xcode 12 Default Dark" instead of "Xcode Classic Dark". This PR fixed this "issue".